### PR TITLE
Make dependencies explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2-beta] - 2021-07-09
 ### Fixed
 - Make dependencies explicit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make dependencies explicit.
 
 ## [0.1.1] - 2021-03-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2021-07-12
 ### Fixed
 - Make dependencies explicit.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.1.2-beta] - 2021-07-09
 ### Fixed
 - Make dependencies explicit.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-add
 $ vtex COMMAND
 running command...
 $ vtex (-v|--version|version)
-@vtex/cli-plugin-add/0.1.1 linux-x64 node-v12.22.1
+@vtex/cli-plugin-add/0.1.2-beta linux-x64 node-v12.22.1
 $ vtex --help [COMMAND]
 USAGE
   $ vtex COMMAND
@@ -63,5 +63,5 @@ EXAMPLE
   vtex add vtex.service-example@0.x
 ```
 
-_See code: [build/commands/add.ts](https://github.com/vtex/cli-plugin-template/blob/v0.1.1/build/commands/add.ts)_
+_See code: [build/commands/add.ts](https://github.com/vtex/cli-plugin-template/blob/v0.1.2-beta/build/commands/add.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-add
 $ vtex COMMAND
 running command...
 $ vtex (-v|--version|version)
-@vtex/cli-plugin-add/0.1.2-beta linux-x64 node-v12.22.1
+@vtex/cli-plugin-add/0.1.2 linux-x64 node-v12.22.1
 $ vtex --help [COMMAND]
 USAGE
   $ vtex COMMAND
@@ -63,5 +63,5 @@ EXAMPLE
   vtex add vtex.service-example@0.x
 ```
 
-_See code: [build/commands/add.ts](https://github.com/vtex/cli-plugin-template/blob/v0.1.2-beta/build/commands/add.ts)_
+_See code: [build/commands/add.ts](https://github.com/vtex/cli-plugin-template/blob/v0.1.2/build/commands/add.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-add
 $ vtex COMMAND
 running command...
 $ vtex (-v|--version|version)
-@vtex/cli-plugin-add/0.1.1 linux-x64 node-v12.21.0
+@vtex/cli-plugin-add/0.1.1 linux-x64 node-v12.22.1
 $ vtex --help [COMMAND]
 USAGE
   $ vtex COMMAND

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-add",
   "description": "vtex plugin add",
-  "version": "0.1.1",
+  "version": "0.1.2-beta",
   "bugs": "https://github.com/vtex/cli-plugin-add/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
+    "chalk": "^4.1.1",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-add",
   "description": "vtex plugin add",
-  "version": "0.1.2-beta",
+  "version": "0.1.2",
   "bugs": "https://github.com/vtex/cli-plugin-add/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2549,6 +2549,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
@@ -8185,7 +8193,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make dependencies explicit.

#### What problem is this solving?
On toolbelt 2.x, our plugins are using implicitly dependencies from the toolbelt. On 3.x, it is not running well, because the way that we are doing is structurally different from 2.x.

When we install a plugin on toolbelt 3.x, using `vtex plugins install [PLUGIN]`, it is installed on `/Users/william/.local/share/vtex/node_modules/@vtex/[PLUGIN]`. To solve the problem of dependencies that the plugin has of toolbelt, a symlink is done from `/Users/william/.config/yarn/global/node_modules/vtex` to `/Users/william/.local/share/vtex/node_modules/vtex`. Diferent of 2.x, in this case the plugin cannot find its implicits dependencies inside of `/Users/william/.local/share/vtex/node_modules/vtex`, because the way that Node.js search, looks only for `path/node_molules` and above “recursively”. Look more about how a require works [here](https://www.freecodecamp.org/news/requiring-modules-in-node-js-everything-you-need-to-know-e7fbd119be8/).
Understanding that our plugins on 3.x are not getting dependencies from inside the toolbelt, we have two initial options: Do another symlink of all dependencies from the toolbelt to the plugin, or install all dependencies explicitly. The second option looks better because we will not have problems with different versions in dev or production environment.

#### How should this be manually tested?
Linking this plugin on toolbelt 3.x.

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`